### PR TITLE
developセキュリティ対応: minimatch脆弱性修正 + Dependabot PR整理 + vuetify更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "sass": "^1.57.1",
         "sass-loader": "^16.0.5",
         "vite-plugin-vuetify": "^2.1.2",
-        "vuetify": "~3.8.0"
+        "vuetify": "~3.11.6"
       },
       "devDependencies": {
         "@nuxtjs/eslint-config-typescript": "^12.0.0",
@@ -18602,13 +18602,10 @@
       "license": "MIT"
     },
     "node_modules/vuetify": {
-      "version": "3.8.12",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.8.12.tgz",
-      "integrity": "sha512-XRX/yRel/V5rlas12ovujVCo8RDb/NwICyef/DVYzybqbYz/UGHZd23sN5q1zw0h9jUN8httXI6ytWN7OFugmA==",
+      "version": "3.11.9",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.11.9.tgz",
+      "integrity": "sha512-XKcaQU+y/ZURLWII4rOX26LgU/wYRjskDVQFQ35OQuTt81wkruyle9sM9RDkFXCYI5zFApaRpBnTzS8uIN6Yog==",
       "license": "MIT",
-      "engines": {
-        "node": "^12.20 || >=14.13"
-      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3354,13 +3354,13 @@
       }
     },
     "node_modules/@nuxtjs/eslint-config-typescript/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6288,13 +6288,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6429,13 +6429,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sass": "^1.57.1",
     "sass-loader": "^16.0.5",
     "vite-plugin-vuetify": "^2.1.2",
-    "vuetify": "~3.8.0"
+    "vuetify": "~3.11.6"
   },
   "overrides": {
     "vite": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "overrides": {
     "vite": {
       "rollup": "npm:@rollup/wasm-node"
-    }
+    },
+    "minimatch@9.0.3": "^9.0.7"
   }
 }


### PR DESCRIPTION
## 概要

`develop` を `main` から切り直し、依存関係のセキュリティ対応を整理した。

## 1. minimatch のReDoS脆弱性を修正 (GHSA-7r86-cg39-jmmj / high)

唯一未解決だった Dependabot alert。`@typescript-eslint/typescript-estree` が
`minimatch@9.0.3` を**完全固定**で参照しているため通常の依存更新では解消できず、
`overrides` で対応した。

- `package.json` に `"minimatch@9.0.3": "^9.0.7"` を追加（9.0.3 のみにスコープ限定）
- ロックファイル上の該当3箇所が 9.0.3 → 9.0.9 に

minimatch を一括 override すると eslint(`^3.1.2`) や glob(`^10.2.2`) の解決が壊れるため、
脆弱な完全固定の 9.0.3 だけを対象にしている。
3.1.5 / 5.1.9 / 10.2.6 の各系統は既に修正済みバージョンのため対象外。

**検証**: `npm audit` 6 high → **0 vulnerabilities**

## 2. 既存の Dependabot PR 16件を整理

`npmアップデート` / `package-lock再生成` により main のロックファイルが
**すでに同等以上のバージョンを保持している**ため、下記はすべて陳腐化しており close した。

### security update (base: main) — 12件

| PR | パッケージ | PRの提案 | main の現状 |
|---|---|---|---|
| #120 | node-forge | 1.4.0 | 1.4.0 (同一) |
| #119 | srvx | 0.11.13 | 0.11.22 |
| #118 | picomatch | — | 2.3.2 / 4.0.5 (両方 patched) |
| #117 | flatted | 3.4.2 | 3.4.4 |
| #116 | h3 | 1.15.9 | 1.15.11 |
| #114 | devalue | 5.6.4 | 5.9.0 |
| #113 | tar | 7.5.11 | 7.5.22 |
| #112 | simple-git | 3.33.0 | 3.36.0 |
| #110 | immutable | 5.1.5 | 5.1.9 |
| #109 | svgo | 4.0.1 | 4.0.2 |
| #108 | rollup | 4.59.0 | 4.62.4 |
| #99 | lodash | 4.17.23 | 4.18.1 |

\#120 / \#113 / \#99 で実際に test-merge して確認済み。いずれも `package-lock.json` で
conflict し、解決すると main 側が採用される（= マージしても no-op か downgrade）。

### version update (base: develop) — 4件

\#86 (nuxt 3.20.2) / \#92 (rollup 4.55.1) / \#93 (sass 1.97.2) / \#96 (postcss-html 1.8.1)。
develop を main から切り直したことで、いずれも develop の現状バージョンが上回ったため close。

## 3. vuetify を 3.11.9 に更新 (#88 相当)

\#88 のみ main(3.8.12) より新しい中身があったため取り込んだ。
ただし **PR ブランチは develop より30コミット遅れ**ており、そのままマージすると
ロックファイルが巻き戻って minimatch(9.0.3 等) / tar(7.5.2) / lodash(4.17.21) /
h3(1.15.4) の脆弱性が復活するため、**マージせず develop 上で直接バージョンを上げた**。

- `package.json`: `vuetify` `~3.8.0` → `~3.11.6`（#88 と同じ指定）
- 解決バージョン: 3.8.12 → **3.11.9**、他の依存は巻き戻りなし

**検証**: `nuxi build` 成功（Server built in 11.7s）、`npm audit` 0 vulnerabilities

## 補足

- minimatch の alert は default branch (main) 基準で追跡されるため、このPRがマージされるまで open のまま。
- **既存の未対応問題**: `.npmrc` が pnpm 用設定（`shamefully-hoist` / `strict-peer-dependencies`）
  なのに `package-lock.json` 運用のため、`eslint-plugin-import` が hoist されず `npx eslint` が
  実行不能。今回のスコープ外。
